### PR TITLE
Add a health endpoint

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -34,6 +34,10 @@ server {
         access_log off;
     }
 
+    location /webdav_health {
+        content_by_lua_file /etc/nginx/lua/test_health_content.lua;
+    }
+
     location /webdav {
         rewrite_log on;
         rewrite ^/webdav/(.*) /$upstream_location/$1 last;

--- a/nginx/lua/config.lua
+++ b/nginx/lua/config.lua
@@ -22,6 +22,10 @@ nYRpXnJvRswePD3s0nSYwAWr7TyRm5r/UCr5MoZpWSUg3eBKw5YFiWY8EIBu70Ys
 I0VY97z1mRO4S1TXwUwzr3NlB3JPmnJUKGRlh6ZceKnqGQWieS87rOn1aEUWNcxa
 LwIDAQAB
 -----END PUBLIC KEY-----]],
+       -- To be able to confirm that the test server is the same one we spoke
+       -- to, have the health check reply this ID. So the test sets the ID and
+       -- the service replies with the same number
+       health_check_id = -1,
     }
 }
 

--- a/nginx/lua/test_health_content.lua
+++ b/nginx/lua/test_health_content.lua
@@ -2,11 +2,9 @@ local config = require("config")
 
 -- A health check
 local json = require('cjson')
-json_string = json.encode(config.data)
-print (json_string)
 ngx.status = ngx.HTTP_OK
 if config.data["health_check_id"] and config.data["health_check_id"] ~= nil then
-  ngx.say("OK" .. config.data["health_check_id"])
+  ngx.say("OK " .. config.data["health_check_id"])
 else
   ngx.say("OK")
 end

--- a/nginx/lua/test_health_content.lua
+++ b/nginx/lua/test_health_content.lua
@@ -1,0 +1,14 @@
+local config = require("config")
+
+-- A health check
+local json = require('cjson')
+json_string = json.encode(config.data)
+print (json_string)
+ngx.status = ngx.HTTP_OK
+if config.data["health_check_id"] and config.data["health_check_id"] ~= nil then
+  ngx.say("OK" .. config.data["health_check_id"])
+else
+  ngx.say("OK")
+end
+
+return ngx.exit(ngx.HTTP_OK)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,7 +188,7 @@ def nginx_server(setup_server) -> Iterator[str]:
     for _ in range(10):
         try:
             time.sleep(0.1)
-            httpx.get("http://localhost:8080/")
+            httpx.get("http://localhost:8080/webdav_health/")
             break
         except httpx.HTTPError:
             pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
+import datetime
 import json
 import os
-import subprocess
+import random
 import time
+import socket
+import subprocess
 import uuid
+import logging
+
 from dataclasses import dataclass
 from typing import Iterator
 
@@ -13,6 +18,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+logger = logging.getLogger()
 
 @dataclass
 class MockIdP:
@@ -121,6 +127,10 @@ def setup_server(oidc_mock_idp: MockIdP):
         "openidc_pubkey": oidc_mock_idp.public_key_pem,
         "receive_buffer_size": 4096,
         "performance_marker_threshold": 2 * 4096,
+        # Give the container a (hopefully) unique ID that is returned in a
+        # health check so that we can verify that the service we started is the
+        # same one we're connecting to
+        "health_check_id": random.randint(0, 1024*1024*1024)
     }
     with open("nginx/lua/config.json", "w") as f:
         json.dump(config, f)


### PR DESCRIPTION
Needed for deploying on k8s anyway, we need a way to ask if the service is up. In this case, we add a bit which reads config values from the config.json to make a unique ID, which the testing harness uses to make sure that it's talking to the right server (this adds the ID, the consumer code will come later)